### PR TITLE
update rocket to track nightly changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -546,22 +546,22 @@ dependencies = [
 
 [[package]]
 name = "rocket_codegen"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_contrib"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -665,9 +665,9 @@ version = "0.1.0"
 dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_contrib 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,9 +880,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
-"checksum rocket 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "59c98ff9698749d2e462ada372900270b133d038b818448f40ec7627fa18902b"
-"checksum rocket_codegen 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "67b0c2f30efe07fcad87ab87401202aeb1b6388fdc08141460e3ea6eed5a28fd"
-"checksum rocket_contrib 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "798f1a1ff5745078884e841f9de867031a31301f02e3ae924426d08e6f033bfe"
+"checksum rocket 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "8c78f181913214426ebfa478806360c4c00200c08b8bd9b176f4d5d868c29752"
+"checksum rocket_codegen 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "a19a861e7aab19c0319cc1ebfb65ef0e59e3e9386f34df66d93b24ec3ab70299"
+"checksum rocket_contrib 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "d14af6aa8061360879f346084609654133c6c62e50a35f4844c4605c61f9987d"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"


### PR DESCRIPTION
A change in rust around 2018-06-10 broke Rocket, the fix is to upgrade
to rocket 0.3.13, but this may now *require* nightly 2018-06-18 (the one
I tested on) or later.