### PR TITLE
Provide a secret key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ ENV ROCKET_ENV "production"
 ENV ROCKET_PORT 9238
 ENV ROCKET_LIMITS "{json=10485760}"
 
+# syntect_server does not need a secret key since it uses no cookies, but
+# without one set Rocket emits a warning.
+ENV ROCKET_SECRET_KEY "+SecretKeyIsIrrelevantAndUnusedPleaseIgnore="
+
 RUN addgroup -S sourcegraph && adduser -S -G sourcegraph -h /home/sourcegraph sourcegraph
 USER sourcegraph
 


### PR DESCRIPTION
Rocket wants a secret key for "production". In our use case,
the secret key is completely irrelevant, but we have to suppress
the pointless diagnostic. OR DO WE?!?

This will allow us to remove a '| grep -v "Warning: environment is"'
from code elsewhere.