### PR TITLE
add reproducible Docker builds again

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,11 @@ By default on startup, `syntect_server` will list all features (themes + file ty
 
 ## Building
 
-Invoke `cargo build --release` and an optimized binary will be built (e.g. to `./target/debug/syntect_server`).
+Invoke `cargo build --release` and an optimized binary will be built (e.g. to `./target/release/syntect_server`).
 
 ## Building docker image
 
-- MacOS
-  - `brew install filosottile/musl-cross/musl-cross`
-  - `rustup target add x86_64-unknown-linux-musl`
-  - `./build.sh` -> then `./publish.sh` to push the docker image.
-
-- Debian / Ubuntu
-  - `sudo apt-get install musl-tools`
-  - `rustup target add x86_64-unknown-linux-musl`
-  - `./build.debian.sh` -> then `./publish.sh` to push the docker image.
-
-You can then run it via `docker run -it syntect_server`.
+`./build.sh` will build your current repository checkout into a final Docker image.
 
 ## Publishing docker image
 
@@ -91,7 +81,7 @@ Run `./publish.sh` after merging your changes.
 - With a `.sublime-syntax` file:
   - Save the file anywhere under `Packages/MySyntax` [in our fork of sublimehq/Packages](https://github.com/slimsag/Packages).
   - In our fork of syntect
-    - update the git submodule 
+    - update the git submodule
     - run `make assets`
     - commit those changes and submit a PR to the syntect fork
   - Build a new binary.

--- a/build.debian.sh
+++ b/build.debian.sh
@@ -1,3 +1,0 @@
-set -ex
-env 'CC_x86_64-unknown-linux-musl=musl-gcc' cargo rustc --release --target x86_64-unknown-linux-musl -- -C 'linker=musl-gcc'
-docker build --no-cache -t sourcegraph/syntect_server .

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,2 @@
 set -ex
-env 'CC_x86_64-unknown-linux-musl=x86_64-linux-musl-gcc' cargo rustc --release --target x86_64-unknown-linux-musl -- -C 'linker=x86_64-linux-musl-gcc'
-docker build --no-cache -t sourcegraph/syntect_server .
+docker build -t sourcegraph/syntect_server .


### PR DESCRIPTION
Previously, Docker builds without relying on the host were added as part of #18
but later reverted for an unrelated reason. This approach is better for two
reasons:

1. The version of Rust nightly is pinned, so it'll always work (e.g. right now
   we can't use the latest nightly).
2. We now use `sourcegraph/alpine` as our base image, which sets up a `sourcegraph`
   user for us.

Fixes #8 again.