### PR TITLE
Remove line endings

### DIFF
--- a/src/css_table.rs
+++ b/src/css_table.rs
@@ -122,10 +122,14 @@ impl<'a> ClassedTableGenerator<'a> {
         let mut span_empty = false;
         let mut span_start = 0;
 
+        fn trim_newline(s: &str) -> &str {
+            s.trim_end_matches(|c| c == '\n').trim_end_matches(|c| c == '\r')
+        }
+
         for &(i, ref op) in ops {
             if i > cur_index {
                 span_empty = false;
-                write!(&mut self.html, "{}", Escape(&line[cur_index..i])).unwrap();
+                write!(&mut self.html, "{}", Escape(trim_newline(&line[cur_index..i]))).unwrap();
                 cur_index = i
             }
             let mut stack = self.stack.clone();
@@ -146,7 +150,7 @@ impl<'a> ClassedTableGenerator<'a> {
             });
             self.stack = stack;
         }
-        write!(&mut self.html, "{}", Escape(&line[cur_index..line.len()])).unwrap();
+        write!(&mut self.html, "{}", Escape(trim_newline(&line[cur_index..]))).unwrap();
     }
 
     // write_classes_for_scope is modified from highlight::scope_to_classes

--- a/src/css_table.rs
+++ b/src/css_table.rs
@@ -258,7 +258,7 @@ mod tests {
                                     <td class=\"code\">\
                                         <span class=\"hl-source hl-go\">\
                                             <span class=\"hl-keyword hl-other hl-package hl-go\">package</span> \
-                                            <span class=\"hl-variable hl-other hl-go\">main</span>\n\
+                                            <span class=\"hl-variable hl-other hl-go\">main</span>\
                                         </span>\
                                     </td>\
                                 </tr>\
@@ -319,14 +319,14 @@ mod tests {
                                                     </span>\
                                                 </span>\
                                             </span>\
-                                            <span class=\"hl-punctuation hl-terminator hl-java\">;</span>\n\
+                                            <span class=\"hl-punctuation hl-terminator hl-java\">;</span>\
                                         </span>\
                                     </td>\
                                 </tr>\
                                 <tr>\
                                     <td class=\"line\" data-line=\"2\"/>\
                                     <td class=\"code\">\
-                                        <span class=\"hl-source hl-java\">\n</span>\
+                                        <span class=\"hl-source hl-java\"></span>\
                                     </td>\
                                 </tr>\
                                 <tr>\


### PR DESCRIPTION
The newline characters were not being removed from the highlighted code,
which was causing line counts for codecov to show up on a new line.

Fixes sourcegraph/sourcegraph#20397