### PR TITLE
update alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN git checkout v1.0.4 && go build -o /http-server-stabilizer .
 #######################
 # Compile final image #
 #######################
-FROM sourcegraph/alpine-3.12:104987_2021-08-13_a2974ca@sha256:6a602f7ea397a0b44a79596768b13017a5c71f735936989f80e891aebc31e600
+FROM sourcegraph/alpine-3.12:106643_2021-08-30_7f4b12a@sha256:5176711adb03e08bed6f231255aa408f1e1dc67429346e6d5a6811e352e06b88
 COPY --from=ss syntect_server /
 COPY --from=hss http-server-stabilizer /
 


### PR DESCRIPTION
update alpine base image for CVE CVE-2021-25218

[_Created by Sourcegraph batch change `dave/update-alpine`._](https://k8s.sgdev.org/users/dave/batch-changes/update-alpine)