### PR TITLE
update alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN git checkout v1.0.4 && go build -o /http-server-stabilizer .
 #######################
 # Compile final image #
 #######################
-FROM sourcegraph/alpine-3.12:106643_2021-08-30_7f4b12a@sha256:5176711adb03e08bed6f231255aa408f1e1dc67429346e6d5a6811e352e06b88
+FROM sourcegraph/alpine-3.12:107969_2021-09-10_80f5edc@sha256:ce1ba2f16ec56e5e8007da53e0e6449bc0fa1fe1f972bffbc33dea1ae410b86d
 COPY --from=ss syntect_server /
 COPY --from=hss http-server-stabilizer /
 


### PR DESCRIPTION
update alpine base image for CVE CVE-2021-25218

[_Created by Sourcegraph batch change `dave/update-alpine`._](https://k8s.sgdev.org/users/dave/batch-changes/update-alpine)